### PR TITLE
feat(widgets): allow strings as valid text widgets

### DIFF
--- a/common/src/main/java/earth/terrarium/olympus/client/components/Widgets.java
+++ b/common/src/main/java/earth/terrarium/olympus/client/components/Widgets.java
@@ -267,4 +267,14 @@ public final class Widgets {
         factory.accept(widget);
         return widget;
     }
+
+    public static TextWidget text(String text) {
+        return new TextWidget(Component.literal(text));
+    }
+
+    public static TextWidget text(String text, Consumer<TextWidget> factory) {
+        TextWidget widget = text(Component.literal(text));
+        factory.accept(widget);
+        return widget;
+    }
 }


### PR DESCRIPTION
I know Components are better and stuff
butttt this is better than needing to do `Widgets.text(Text.of("string"))` all the time when just trying to get a plain string