### PR TITLE
Add ModMenu library badge on Fabric

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -19,5 +19,10 @@
         "minecraft": ">=1.21.5",
         "java": ">=21",
         "resourcefullib": ">=3.3.0"
+    },
+    "custom": {
+        "modmenu": {
+            "badges": ["library"]
+        }
     }
 }


### PR DESCRIPTION
This tells ModMenu that the mod is a library and so fixes the mod being shown in the menu even when the user wants library mods hidden.