### PR TITLE
Fix marker map widget marker rotation

### DIFF
--- a/common/src/main/java/earth/terrarium/olympus/client/components/map/MapWidget.java
+++ b/common/src/main/java/earth/terrarium/olympus/client/components/map/MapWidget.java
@@ -112,7 +112,7 @@ public class MapWidget extends BaseWidget {
 
         try (var pose = new CloseablePoseStack(graphics)) {
             pose.translate(this.getX() + left + x, this.getY() + top + y, 0.0);
-            pose.mulPose(Axis.ZP.rotationDegrees(player.getYRot()));
+            pose.mulPose(Axis.ZP.rotationDegrees(player.getYRot() + 180));
             pose.translate(-4f, -4f, 0f);
             graphics.blit(MAP_ICONS, 0, 0, 0f, 0f, 8, 8, 8, 8);
         }


### PR DESCRIPTION
I was looking at updating Odyssey Claims and I noticed the map marker rotation was wrong.

<img width="1080" height="760" alt="Screenshot 2025-11-01 at 02 27 59" src="https://github.com/user-attachments/assets/dfb95252-f152-4087-b3ce-5647193fe4dd" />

You can see the marker now faces north instead of south.

I'm a bit confused on the versioning for Olympus because you have a 1.0.18 version which seems to work on 1.21.1 but only the 1.0.13 version is present on this branch.
